### PR TITLE
Implement subscription edge cases (issue #3)

### DIFF
--- a/src/main/java/org/tw/token_billing/controller/UsageController.java
+++ b/src/main/java/org/tw/token_billing/controller/UsageController.java
@@ -27,9 +27,15 @@ public class UsageController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @ExceptionHandler(UsageService.CustomerNotFoundException.class)
-    public ResponseEntity<ErrorResponse> handleCustomerNotFound(UsageService.CustomerNotFoundException ex) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(UsageService.NoActiveSubscriptionException.class)
+    public ResponseEntity<ErrorResponse> handleNoActiveSubscription(UsageService.NoActiveSubscriptionException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+            .body(new ErrorResponse(ex.getMessage()));
+    }
+
+    @ExceptionHandler(UsageService.MultipleSubscriptionsException.class)
+    public ResponseEntity<ErrorResponse> handleMultipleSubscriptions(UsageService.MultipleSubscriptionsException ex) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
             .body(new ErrorResponse(ex.getMessage()));
     }
 

--- a/src/main/java/org/tw/token_billing/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/tw/token_billing/exception/GlobalExceptionHandler.java
@@ -191,6 +191,36 @@ public class GlobalExceptionHandler {
         return problemDetail;
     }
 
+    /**
+     * SRS-F-7 / AC6: customer exists but has zero active subscriptions.
+     */
+    @ExceptionHandler(NoActiveSubscriptionException.class)
+    public ProblemDetail handleNoActiveSubscription(NoActiveSubscriptionException ex) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
+            HttpStatus.CONFLICT,
+            "Customer '" + ex.getCustomerId() + "' has no active subscription"
+        );
+        problemDetail.setType(DEFAULT_TYPE);
+        problemDetail.setTitle("No active subscription");
+        problemDetail.setInstance(URI.create("/api/usage"));
+        return problemDetail;
+    }
+
+    /**
+     * SRS-F-7: customer has 2+ active subscriptions; treated as data integrity error.
+     */
+    @ExceptionHandler(MultipleActiveSubscriptionsException.class)
+    public ProblemDetail handleMultipleActiveSubscriptions(MultipleActiveSubscriptionsException ex) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "Multiple active subscriptions found for customer '" + ex.getCustomerId() + "'"
+        );
+        problemDetail.setType(DEFAULT_TYPE);
+        problemDetail.setTitle("Data integrity error");
+        problemDetail.setInstance(URI.create("/api/usage"));
+        return problemDetail;
+    }
+
     private ProblemDetail createProblemDetail(HttpStatus status, String title, String detail) {
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
             HttpStatusCode.valueOf(status.value()),

--- a/src/main/java/org/tw/token_billing/exception/MultipleActiveSubscriptionsException.java
+++ b/src/main/java/org/tw/token_billing/exception/MultipleActiveSubscriptionsException.java
@@ -1,0 +1,15 @@
+package org.tw.token_billing.exception;
+
+public class MultipleActiveSubscriptionsException extends RuntimeException {
+
+    private final String customerId;
+
+    public MultipleActiveSubscriptionsException(String customerId) {
+        super("Multiple active subscriptions found for customer: " + customerId);
+        this.customerId = customerId;
+    }
+
+    public String getCustomerId() {
+        return customerId;
+    }
+}

--- a/src/main/java/org/tw/token_billing/exception/NoActiveSubscriptionException.java
+++ b/src/main/java/org/tw/token_billing/exception/NoActiveSubscriptionException.java
@@ -1,0 +1,15 @@
+package org.tw.token_billing.exception;
+
+public class NoActiveSubscriptionException extends RuntimeException {
+
+    private final String customerId;
+
+    public NoActiveSubscriptionException(String customerId) {
+        super("No active subscription found for customer: " + customerId);
+        this.customerId = customerId;
+    }
+
+    public String getCustomerId() {
+        return customerId;
+    }
+}

--- a/src/main/java/org/tw/token_billing/repository/CustomerSubscriptionRepository.java
+++ b/src/main/java/org/tw/token_billing/repository/CustomerSubscriptionRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.tw.token_billing.entity.CustomerSubscription;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -17,6 +18,17 @@ public interface CustomerSubscriptionRepository extends JpaRepository<CustomerSu
            "AND s.effectiveFrom <= :effectiveDate " +
            "AND (s.effectiveTo IS NULL OR s.effectiveTo >= :effectiveDate)")
     Optional<CustomerSubscription> findActiveSubscription(
+        @Param("customerId") String customerId,
+        @Param("effectiveDate") LocalDate effectiveDate
+    );
+
+    @Query("SELECT s FROM CustomerSubscription s " +
+           "JOIN FETCH s.customer " +
+           "JOIN FETCH s.pricingPlan " +
+           "WHERE s.customer.id = :customerId " +
+           "AND s.effectiveFrom <= :effectiveDate " +
+           "AND (s.effectiveTo IS NULL OR s.effectiveTo >= :effectiveDate)")
+    List<CustomerSubscription> findAllActiveSubscriptions(
         @Param("customerId") String customerId,
         @Param("effectiveDate") LocalDate effectiveDate
     );

--- a/src/main/java/org/tw/token_billing/repository/CustomerSubscriptionRepository.java
+++ b/src/main/java/org/tw/token_billing/repository/CustomerSubscriptionRepository.java
@@ -6,21 +6,9 @@ import org.springframework.data.repository.query.Param;
 import org.tw.token_billing.entity.CustomerSubscription;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 public interface CustomerSubscriptionRepository extends JpaRepository<CustomerSubscription, UUID> {
-
-    @Query("SELECT s FROM CustomerSubscription s " +
-           "JOIN FETCH s.customer " +
-           "JOIN FETCH s.pricingPlan " +
-           "WHERE s.customer.id = :customerId " +
-           "AND s.effectiveFrom <= :effectiveDate " +
-           "AND (s.effectiveTo IS NULL OR s.effectiveTo >= :effectiveDate)")
-    Optional<CustomerSubscription> findActiveSubscription(
-        @Param("customerId") String customerId,
-        @Param("effectiveDate") LocalDate effectiveDate
-    );
 
     @Query("SELECT s FROM CustomerSubscription s " +
            "JOIN FETCH s.customer " +

--- a/src/main/java/org/tw/token_billing/service/UsageService.java
+++ b/src/main/java/org/tw/token_billing/service/UsageService.java
@@ -7,7 +7,11 @@ import org.tw.token_billing.dto.UsageRequest;
 import org.tw.token_billing.entity.Bill;
 import org.tw.token_billing.entity.Customer;
 import org.tw.token_billing.entity.CustomerSubscription;
+import org.tw.token_billing.exception.CustomerNotFoundException;
+import org.tw.token_billing.exception.MultipleActiveSubscriptionsException;
+import org.tw.token_billing.exception.NoActiveSubscriptionException;
 import org.tw.token_billing.repository.BillRepository;
+import org.tw.token_billing.repository.CustomerRepository;
 import org.tw.token_billing.repository.CustomerSubscriptionRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,17 +33,26 @@ public class UsageService {
     private static final MathContext MATH_CONTEXT = new MathContext(10, RoundingMode.HALF_EVEN);
     private static final String CURRENCY_USD = "USD";
 
+    private final CustomerRepository customerRepository;
     private final CustomerSubscriptionRepository subscriptionRepository;
     private final BillRepository billRepository;
 
-    public UsageService(CustomerSubscriptionRepository subscriptionRepository, BillRepository billRepository) {
+    public UsageService(CustomerRepository customerRepository,
+                        CustomerSubscriptionRepository subscriptionRepository,
+                        BillRepository billRepository) {
+        this.customerRepository = customerRepository;
         this.subscriptionRepository = subscriptionRepository;
         this.billRepository = billRepository;
     }
 
     @Transactional
     public BillResponse calculateBill(UsageRequest request) {
-        // Validate customer exists and has active subscription
+        // SRS-F-6 step 4: customer existence (404 before subscription lookup)
+        if (!customerRepository.existsById(request.getCustomerId())) {
+            throw new CustomerNotFoundException(request.getCustomerId());
+        }
+
+        // SRS-F-7: active subscription resolution
         LocalDate today = LocalDate.now(ZoneOffset.UTC);
         List<CustomerSubscription> subscriptions = subscriptionRepository
             .findAllActiveSubscriptions(request.getCustomerId(), today);
@@ -47,40 +60,33 @@ public class UsageService {
         if (subscriptions.isEmpty()) {
             throw new NoActiveSubscriptionException(request.getCustomerId());
         }
-
         if (subscriptions.size() > 1) {
             log.error("Multiple active subscriptions for customerId={}", request.getCustomerId());
-            throw new MultipleSubscriptionsException(request.getCustomerId());
+            throw new MultipleActiveSubscriptionsException(request.getCustomerId());
         }
 
         CustomerSubscription subscription = subscriptions.get(0);
-
         Customer customer = subscription.getCustomer();
         int quota = subscription.getPricingPlan().getMonthlyQuota();
         BigDecimal overageRatePer1k = subscription.getPricingPlan().getOverageRatePer1k();
 
-        // Calculate total tokens
         int totalTokens = request.getPromptTokens() + request.getCompletionTokens();
 
-        // Get current month usage
         Instant monthStart = today.with(TemporalAdjusters.firstDayOfMonth())
             .atStartOfDay(ZoneOffset.UTC)
             .toInstant();
         long currentMonthUsage = billRepository.sumTotalTokensByCustomerIdAndMonthStart(
             request.getCustomerId(), monthStart);
 
-        // Calculate tokens from quota and overage
         long availableQuota = Math.max(0L, (long) quota - currentMonthUsage);
         int tokensFromQuota = (int) Math.min((long) totalTokens, availableQuota);
         int overageTokens = totalTokens - tokensFromQuota;
 
-        // Calculate charge: (overageTokens / 1000) × overageRatePer1k
         BigDecimal charge = BigDecimal.valueOf(overageTokens)
             .divide(BigDecimal.valueOf(1000), MATH_CONTEXT)
             .multiply(overageRatePer1k)
             .setScale(2, RoundingMode.HALF_EVEN);
 
-        // Create and save the bill
         Instant calculatedAt = Instant.now();
         Bill bill = new Bill(
             UUID.randomUUID(),
@@ -95,7 +101,6 @@ public class UsageService {
         );
         billRepository.save(bill);
 
-        // Build response in camelCase
         return new BillResponse(
             bill.getId(),
             customer.getId(),
@@ -108,17 +113,5 @@ public class UsageService {
             CURRENCY_USD,
             bill.getCalculatedAt()
         );
-    }
-
-    public static class NoActiveSubscriptionException extends RuntimeException {
-        public NoActiveSubscriptionException(String customerId) {
-            super("No active subscription found for customer: " + customerId);
-        }
-    }
-
-    public static class MultipleSubscriptionsException extends RuntimeException {
-        public MultipleSubscriptionsException(String customerId) {
-            super("Multiple active subscriptions found for customer: " + customerId);
-        }
     }
 }

--- a/src/main/java/org/tw/token_billing/service/UsageService.java
+++ b/src/main/java/org/tw/token_billing/service/UsageService.java
@@ -1,5 +1,7 @@
 package org.tw.token_billing.service;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.tw.token_billing.dto.BillResponse;
 import org.tw.token_billing.dto.UsageRequest;
 import org.tw.token_billing.entity.Bill;
@@ -17,11 +19,13 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.temporal.TemporalAdjusters;
+import java.util.List;
 import java.util.UUID;
 
 @Service
 public class UsageService {
 
+    private static final Logger log = LoggerFactory.getLogger(UsageService.class);
     private static final MathContext MATH_CONTEXT = new MathContext(10, RoundingMode.HALF_EVEN);
     private static final String CURRENCY_USD = "USD";
 
@@ -37,9 +41,19 @@ public class UsageService {
     public BillResponse calculateBill(UsageRequest request) {
         // Validate customer exists and has active subscription
         LocalDate today = LocalDate.now(ZoneOffset.UTC);
-        CustomerSubscription subscription = subscriptionRepository
-            .findActiveSubscription(request.getCustomerId(), today)
-            .orElseThrow(() -> new CustomerNotFoundException(request.getCustomerId()));
+        List<CustomerSubscription> subscriptions = subscriptionRepository
+            .findAllActiveSubscriptions(request.getCustomerId(), today);
+
+        if (subscriptions.isEmpty()) {
+            throw new NoActiveSubscriptionException(request.getCustomerId());
+        }
+
+        if (subscriptions.size() > 1) {
+            log.error("Multiple active subscriptions for customerId={}", request.getCustomerId());
+            throw new MultipleSubscriptionsException(request.getCustomerId());
+        }
+
+        CustomerSubscription subscription = subscriptions.get(0);
 
         Customer customer = subscription.getCustomer();
         int quota = subscription.getPricingPlan().getMonthlyQuota();
@@ -96,9 +110,15 @@ public class UsageService {
         );
     }
 
-    public static class CustomerNotFoundException extends RuntimeException {
-        public CustomerNotFoundException(String customerId) {
-            super("Active subscription not found for customer: " + customerId);
+    public static class NoActiveSubscriptionException extends RuntimeException {
+        public NoActiveSubscriptionException(String customerId) {
+            super("No active subscription found for customer: " + customerId);
+        }
+    }
+
+    public static class MultipleSubscriptionsException extends RuntimeException {
+        public MultipleSubscriptionsException(String customerId) {
+            super("Multiple active subscriptions found for customer: " + customerId);
         }
     }
 }

--- a/src/main/resources/db/migration/V1__Create_tables.sql
+++ b/src/main/resources/db/migration/V1__Create_tables.sql
@@ -52,10 +52,17 @@ INSERT INTO pricing_plans (id, name, monthly_quota, overage_rate_per_1k) VALUES
 INSERT INTO customers (id, name) VALUES
     ('CUST-001', 'Acme Corp'),
     ('CUST-002', 'TechStart Inc'),
-    ('CUST-003', 'Enterprise Solutions Ltd');
+    ('CUST-003', 'Enterprise Solutions Ltd'),
+    ('CUST-004', 'No Active Sub Corp'),
+    ('CUST-005', 'Multi Sub Corp');
 
 -- Seed data: subscriptions
-INSERT INTO customer_subscriptions (id, customer_id, plan_id, effective_from) VALUES
-    ('a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'CUST-001', 'PLAN-STARTER', '2026-01-01'),
-    ('b2c3d4e5-f6a7-8901-bcde-f12345678901', 'CUST-002', 'PLAN-FREE', '2026-02-01'),
-    ('c3d4e5f6-a7b8-9012-cdef-123456789012', 'CUST-003', 'PLAN-ENTERPRISE', '2026-01-15');
+INSERT INTO customer_subscriptions (id, customer_id, plan_id, effective_from, effective_to) VALUES
+    ('a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'CUST-001', 'PLAN-STARTER', '2026-01-01', NULL),
+    ('b2c3d4e5-f6a7-8901-bcde-f12345678901', 'CUST-002', 'PLAN-FREE', '2026-02-01', NULL),
+    ('c3d4e5f6-a7b8-9012-cdef-123456789012', 'CUST-003', 'PLAN-ENTERPRISE', '2026-01-15', NULL),
+    -- CUST-004: expired subscription (effective_to = today - 1) -> no active subscription
+    ('d4e5f6a7-a8b9-0123-def0-234567890123', 'CUST-004', 'PLAN-STARTER', '2026-01-01', '2026-05-01'),
+    -- CUST-005: multiple active subscriptions -> data integrity error
+    ('e5f6a7b8-b9c0-1234-ef01-345678901234', 'CUST-005', 'PLAN-STARTER', '2026-01-01', NULL),
+    ('f6a7b8c9-c0d1-2345-f012-456789012345', 'CUST-005', 'PLAN-PRO', '2026-01-01', NULL);

--- a/src/main/resources/db/migration/V1__Create_tables.sql
+++ b/src/main/resources/db/migration/V1__Create_tables.sql
@@ -54,7 +54,9 @@ INSERT INTO customers (id, name) VALUES
     ('CUST-002', 'TechStart Inc'),
     ('CUST-003', 'Enterprise Solutions Ltd'),
     ('CUST-004', 'No Active Sub Corp'),
-    ('CUST-005', 'Multi Sub Corp');
+    ('CUST-005', 'Multi Sub Corp'),
+    -- CUST-006: customer exists but has zero rows in customer_subscriptions
+    ('CUST-006', 'Never Subscribed Corp');
 
 -- Seed data: subscriptions. effective_from uses a far-past date so rows stay
 -- active regardless of system clock. CUST-004's effective_to is fixed in the

--- a/src/main/resources/db/migration/V1__Create_tables.sql
+++ b/src/main/resources/db/migration/V1__Create_tables.sql
@@ -56,13 +56,15 @@ INSERT INTO customers (id, name) VALUES
     ('CUST-004', 'No Active Sub Corp'),
     ('CUST-005', 'Multi Sub Corp');
 
--- Seed data: subscriptions
+-- Seed data: subscriptions. effective_from uses a far-past date so rows stay
+-- active regardless of system clock. CUST-004's effective_to is fixed in the
+-- past (also independent of clock) so it remains expired.
 INSERT INTO customer_subscriptions (id, customer_id, plan_id, effective_from, effective_to) VALUES
-    ('a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'CUST-001', 'PLAN-STARTER', '2026-01-01', NULL),
-    ('b2c3d4e5-f6a7-8901-bcde-f12345678901', 'CUST-002', 'PLAN-FREE', '2026-02-01', NULL),
-    ('c3d4e5f6-a7b8-9012-cdef-123456789012', 'CUST-003', 'PLAN-ENTERPRISE', '2026-01-15', NULL),
-    -- CUST-004: expired subscription (effective_to = today - 1) -> no active subscription
-    ('d4e5f6a7-a8b9-0123-def0-234567890123', 'CUST-004', 'PLAN-STARTER', '2026-01-01', '2026-05-01'),
-    -- CUST-005: multiple active subscriptions -> data integrity error
-    ('e5f6a7b8-b9c0-1234-ef01-345678901234', 'CUST-005', 'PLAN-STARTER', '2026-01-01', NULL),
-    ('f6a7b8c9-c0d1-2345-f012-456789012345', 'CUST-005', 'PLAN-PRO', '2026-01-01', NULL);
+    ('a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'CUST-001', 'PLAN-STARTER',    '2020-01-01', NULL),
+    ('b2c3d4e5-f6a7-8901-bcde-f12345678901', 'CUST-002', 'PLAN-FREE',       '2020-01-01', NULL),
+    ('c3d4e5f6-a7b8-9012-cdef-123456789012', 'CUST-003', 'PLAN-ENTERPRISE', '2020-01-01', NULL),
+    -- CUST-004: expired subscription -> no active subscription (HTTP 409)
+    ('d4e5f6a7-a8b9-0123-def0-234567890123', 'CUST-004', 'PLAN-STARTER',    '2020-01-01', '2020-01-02'),
+    -- CUST-005: multiple active subscriptions -> data integrity error (HTTP 500)
+    ('e5f6a7b8-b9c0-1234-ef01-345678901234', 'CUST-005', 'PLAN-STARTER',    '2020-01-01', NULL),
+    ('f6a7b8c9-c0d1-2345-f012-456789012345', 'CUST-005', 'PLAN-PRO',        '2020-01-01', NULL);

--- a/src/test/java/org/tw/token_billing/controller/UsageControllerTest.java
+++ b/src/test/java/org/tw/token_billing/controller/UsageControllerTest.java
@@ -100,17 +100,32 @@ class UsageControllerTest {
     }
 
     @Test
-    void submitUsage_customerNotFound_returns404() throws Exception {
+    void submitUsage_noActiveSubscription_returns409() throws Exception {
         when(usageService.calculateBill(any(UsageRequest.class)))
-            .thenThrow(new UsageService.CustomerNotFoundException("CUST-MISSING"));
+            .thenThrow(new UsageService.NoActiveSubscriptionException("CUST-MISSING"));
 
         UsageRequest request = new UsageRequest("CUST-MISSING", 100, 100);
 
         mockMvc.perform(post("/api/usage")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
-            .andExpect(status().isNotFound())
+            .andExpect(status().isConflict())
             .andExpect(jsonPath("$.message").value(
                 org.hamcrest.Matchers.containsString("CUST-MISSING")));
+    }
+
+    @Test
+    void submitUsage_multipleSubscriptions_returns500() throws Exception {
+        when(usageService.calculateBill(any(UsageRequest.class)))
+            .thenThrow(new UsageService.MultipleSubscriptionsException("CUST-DUP"));
+
+        UsageRequest request = new UsageRequest("CUST-DUP", 100, 100);
+
+        mockMvc.perform(post("/api/usage")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isInternalServerError())
+            .andExpect(jsonPath("$.message").value(
+                org.hamcrest.Matchers.containsString("CUST-DUP")));
     }
 }

--- a/src/test/java/org/tw/token_billing/controller/UsageControllerTest.java
+++ b/src/test/java/org/tw/token_billing/controller/UsageControllerTest.java
@@ -10,6 +10,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.tw.token_billing.dto.BillResponse;
 import org.tw.token_billing.dto.UsageRequest;
 import org.tw.token_billing.exception.CustomerNotFoundException;
+import org.tw.token_billing.exception.MultipleActiveSubscriptionsException;
+import org.tw.token_billing.exception.NoActiveSubscriptionException;
 import org.tw.token_billing.service.UsageService;
 
 import java.math.BigDecimal;
@@ -217,5 +219,45 @@ class UsageControllerTest {
             .andExpect(jsonPath("$.status").value(400));
 
         verify(usageService, never()).calculateBill(any(UsageRequest.class));
+    }
+
+    // AC6: 409 - Customer exists but has no active subscription (RFC 7807)
+    @Test
+    void submitUsage_noActiveSubscription_returns409WithRfc7807() throws Exception {
+        when(usageService.calculateBill(any(UsageRequest.class)))
+            .thenThrow(new NoActiveSubscriptionException("CUST-NOSUB"));
+
+        UsageRequest request = new UsageRequest("CUST-NOSUB", 100, 100);
+
+        mockMvc.perform(post("/api/usage")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isConflict())
+            .andExpect(content().contentTypeCompatibleWith("application/problem+json"))
+            .andExpect(jsonPath("$.type").value("about:blank"))
+            .andExpect(jsonPath("$.title").value("No active subscription"))
+            .andExpect(jsonPath("$.status").value(409))
+            .andExpect(jsonPath("$.detail").value(containsString("CUST-NOSUB")))
+            .andExpect(jsonPath("$.instance").value("/api/usage"));
+    }
+
+    // SRS-F-7: 500 - Multiple active subscriptions (data integrity error, RFC 7807)
+    @Test
+    void submitUsage_multipleActiveSubscriptions_returns500WithRfc7807() throws Exception {
+        when(usageService.calculateBill(any(UsageRequest.class)))
+            .thenThrow(new MultipleActiveSubscriptionsException("CUST-MULTI"));
+
+        UsageRequest request = new UsageRequest("CUST-MULTI", 100, 100);
+
+        mockMvc.perform(post("/api/usage")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isInternalServerError())
+            .andExpect(content().contentTypeCompatibleWith("application/problem+json"))
+            .andExpect(jsonPath("$.type").value("about:blank"))
+            .andExpect(jsonPath("$.title").value("Data integrity error"))
+            .andExpect(jsonPath("$.status").value(500))
+            .andExpect(jsonPath("$.detail").value(containsString("CUST-MULTI")))
+            .andExpect(jsonPath("$.instance").value("/api/usage"));
     }
 }

--- a/src/test/java/org/tw/token_billing/repository/CustomerSubscriptionRepositoryTest.java
+++ b/src/test/java/org/tw/token_billing/repository/CustomerSubscriptionRepositoryTest.java
@@ -1,0 +1,176 @@
+package org.tw.token_billing.repository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.tw.token_billing.entity.Customer;
+import org.tw.token_billing.entity.CustomerSubscription;
+import org.tw.token_billing.entity.PricingPlan;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for CustomerSubscriptionRepository.findAllActiveSubscriptions
+ * against a real PostgreSQL container.
+ *
+ * Covers issue #3 acceptance criteria:
+ *   - effective_from = today (inclusive)
+ *   - effective_to = today (inclusive)
+ *   - effective_to = today - 1 (expired)
+ *   - zero / multiple active rows for a customer (CUST-004 / CUST-005 fixtures)
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+class CustomerSubscriptionRepositoryTest {
+
+    @Container
+    static final PostgreSQLContainer<?> postgres =
+        new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @DynamicPropertySource
+    static void datasourceProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+    }
+
+    @Autowired
+    private CustomerSubscriptionRepository subscriptionRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    private Customer findCustomer(String id) {
+        Customer customer = entityManager.find(Customer.class, id);
+        assertNotNull(customer, "Flyway seed should provide " + id);
+        return customer;
+    }
+
+    private PricingPlan findPlan(String id) {
+        PricingPlan plan = entityManager.find(PricingPlan.class, id);
+        assertNotNull(plan, "Flyway seed should provide " + id);
+        return plan;
+    }
+
+    private Customer freshCustomer(String id) {
+        Customer customer = new Customer(id, "Test " + id, Instant.now());
+        entityManager.persist(customer);
+        return customer;
+    }
+
+    private CustomerSubscription persistSubscription(Customer customer, LocalDate from, LocalDate to) {
+        CustomerSubscription sub = new CustomerSubscription();
+        sub.setId(UUID.randomUUID());
+        sub.setCustomer(customer);
+        sub.setPricingPlan(findPlan("PLAN-STARTER"));
+        sub.setEffectiveFrom(from);
+        sub.setEffectiveTo(to);
+        sub.setCreatedAt(Instant.now());
+        entityManager.persist(sub);
+        return sub;
+    }
+
+    // -------- AC: effective_from = today (inclusive) --------
+
+    @Test
+    void findAll_effectiveFromToday_isActive() {
+        LocalDate today = LocalDate.of(2026, 6, 15);
+        Customer customer = freshCustomer("CUST-BOUND-FROM-TODAY");
+        persistSubscription(customer, today, null);
+        entityManager.flush();
+
+        List<CustomerSubscription> result = subscriptionRepository
+            .findAllActiveSubscriptions(customer.getId(), today);
+
+        assertEquals(1, result.size(),
+            "Subscription whose effective_from equals today is active (inclusive)");
+    }
+
+    // -------- AC: effective_to = today (inclusive) --------
+
+    @Test
+    void findAll_effectiveToToday_isActive() {
+        LocalDate today = LocalDate.of(2026, 6, 15);
+        Customer customer = freshCustomer("CUST-BOUND-TO-TODAY");
+        persistSubscription(customer, today.minusYears(1), today);
+        entityManager.flush();
+
+        List<CustomerSubscription> result = subscriptionRepository
+            .findAllActiveSubscriptions(customer.getId(), today);
+
+        assertEquals(1, result.size(),
+            "Subscription whose effective_to equals today is active on its last day (inclusive)");
+    }
+
+    // -------- AC: effective_to = today - 1 (expired) --------
+
+    @Test
+    void findAll_effectiveToYesterday_isExpired() {
+        LocalDate today = LocalDate.of(2026, 6, 15);
+        Customer customer = freshCustomer("CUST-BOUND-EXPIRED");
+        persistSubscription(customer, today.minusYears(1), today.minusDays(1));
+        entityManager.flush();
+
+        List<CustomerSubscription> result = subscriptionRepository
+            .findAllActiveSubscriptions(customer.getId(), today);
+
+        assertTrue(result.isEmpty(),
+            "Subscription whose effective_to is yesterday must not be returned today");
+    }
+
+    // -------- AC: effective_from = tomorrow (not yet active) --------
+
+    @Test
+    void findAll_effectiveFromTomorrow_isNotYetActive() {
+        LocalDate today = LocalDate.of(2026, 6, 15);
+        Customer customer = freshCustomer("CUST-BOUND-FUTURE");
+        persistSubscription(customer, today.plusDays(1), null);
+        entityManager.flush();
+
+        List<CustomerSubscription> result = subscriptionRepository
+            .findAllActiveSubscriptions(customer.getId(), today);
+
+        assertTrue(result.isEmpty(),
+            "Subscription whose effective_from is tomorrow must not be active today");
+    }
+
+    // -------- AC6: zero active subscriptions on seeded fixture --------
+
+    @Test
+    void findAll_seededCustomerWithExpiredSubscription_returnsEmpty() {
+        // CUST-004 has only an expired (2020-01-01..2020-01-02) row in seed
+        List<CustomerSubscription> result = subscriptionRepository
+            .findAllActiveSubscriptions("CUST-004", LocalDate.of(2026, 6, 15));
+
+        assertTrue(result.isEmpty(),
+            "CUST-004 should have zero active subscriptions per seed fixture");
+    }
+
+    // -------- Multiple active subscriptions on seeded fixture --------
+
+    @Test
+    void findAll_seededCustomerWithMultipleActive_returnsAll() {
+        // CUST-005 has two PLAN-STARTER + PLAN-PRO rows both with NULL effective_to
+        List<CustomerSubscription> result = subscriptionRepository
+            .findAllActiveSubscriptions("CUST-005", LocalDate.of(2026, 6, 15));
+
+        assertEquals(2, result.size(),
+            "CUST-005 should have two active subscriptions per seed fixture");
+    }
+}

--- a/src/test/java/org/tw/token_billing/repository/CustomerSubscriptionRepositoryTest.java
+++ b/src/test/java/org/tw/token_billing/repository/CustomerSubscriptionRepositoryTest.java
@@ -162,6 +162,17 @@ class CustomerSubscriptionRepositoryTest {
             "CUST-004 should have zero active subscriptions per seed fixture");
     }
 
+    @Test
+    void findAll_seededCustomerWithNoSubscriptionRows_returnsEmpty() {
+        // CUST-006 exists in customers but has zero rows in customer_subscriptions.
+        // Distinguishes "never subscribed" from "subscribed-then-expired" (CUST-004).
+        List<CustomerSubscription> result = subscriptionRepository
+            .findAllActiveSubscriptions("CUST-006", LocalDate.of(2026, 6, 15));
+
+        assertTrue(result.isEmpty(),
+            "CUST-006 should have zero subscription rows per seed fixture");
+    }
+
     // -------- Multiple active subscriptions on seeded fixture --------
 
     @Test

--- a/src/test/java/org/tw/token_billing/service/UsageServiceTest.java
+++ b/src/test/java/org/tw/token_billing/service/UsageServiceTest.java
@@ -8,7 +8,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.tw.token_billing.dto.UsageRequest;
 import org.tw.token_billing.entity.*;
+import org.tw.token_billing.exception.CustomerNotFoundException;
+import org.tw.token_billing.exception.MultipleActiveSubscriptionsException;
+import org.tw.token_billing.exception.NoActiveSubscriptionException;
 import org.tw.token_billing.repository.BillRepository;
+import org.tw.token_billing.repository.CustomerRepository;
 import org.tw.token_billing.repository.CustomerSubscriptionRepository;
 
 import java.math.BigDecimal;
@@ -32,6 +36,9 @@ class UsageServiceTest {
     private static final BigDecimal DEFAULT_RATE = new BigDecimal("0.0200");
 
     @Mock
+    private CustomerRepository customerRepository;
+
+    @Mock
     private CustomerSubscriptionRepository subscriptionRepository;
 
     @Mock
@@ -41,7 +48,7 @@ class UsageServiceTest {
 
     @BeforeEach
     void setUp() {
-        usageService = new UsageService(subscriptionRepository, billRepository);
+        usageService = new UsageService(customerRepository, subscriptionRepository, billRepository);
     }
 
     private CustomerSubscription createSubscription(String customerId, int quota, BigDecimal ratePer1k) {
@@ -63,6 +70,8 @@ class UsageServiceTest {
     }
 
     private void mockUsage(CustomerSubscription subscription, long currentMonthUsage) {
+        when(customerRepository.existsById(any()))
+            .thenReturn(true);
         when(subscriptionRepository.findAllActiveSubscriptions(any(), any()))
             .thenReturn(List.of(subscription));
         when(billRepository.sumTotalTokensByCustomerIdAndMonthStart(any(), any()))
@@ -167,11 +176,24 @@ class UsageServiceTest {
     // -------- Errors --------
 
     @Test
+    void calculateBill_customerDoesNotExist_throwsCustomerNotFound() {
+        when(customerRepository.existsById("INVALID")).thenReturn(false);
+
+        var ex = assertThrows(CustomerNotFoundException.class,
+            () -> usageService.calculateBill(new UsageRequest("INVALID", 1000, 1000)));
+        assertTrue(ex.getMessage().contains("INVALID"),
+            "Exception message should include customerId");
+        // SRS-F-6 step 4 short-circuits before subscription lookup
+        verify(subscriptionRepository, never()).findAllActiveSubscriptions(any(), any());
+    }
+
+    @Test
     void calculateBill_noActiveSubscription_throwsException() {
+        when(customerRepository.existsById("CUST-004")).thenReturn(true);
         when(subscriptionRepository.findAllActiveSubscriptions(any(), any()))
             .thenReturn(List.of());
 
-        var ex = assertThrows(UsageService.NoActiveSubscriptionException.class,
+        var ex = assertThrows(NoActiveSubscriptionException.class,
             () -> usageService.calculateBill(new UsageRequest("CUST-004", 1000, 1000)));
         assertTrue(ex.getMessage().contains("CUST-004"),
             "Exception message should include customerId");
@@ -181,12 +203,13 @@ class UsageServiceTest {
 
     @Test
     void calculateBill_multipleActiveSubscriptions_throwsException() {
+        when(customerRepository.existsById("CUST-005")).thenReturn(true);
         var sub1 = createSubscription("CUST-005", DEFAULT_QUOTA, DEFAULT_RATE);
         var sub2 = createSubscription("CUST-005", 500000, new BigDecimal("0.0150"));
         when(subscriptionRepository.findAllActiveSubscriptions(any(), any()))
             .thenReturn(List.of(sub1, sub2));
 
-        var ex = assertThrows(UsageService.MultipleSubscriptionsException.class,
+        var ex = assertThrows(MultipleActiveSubscriptionsException.class,
             () -> usageService.calculateBill(new UsageRequest("CUST-005", 1000, 1000)));
         assertTrue(ex.getMessage().contains("CUST-005"),
             "Exception message should include customerId");

--- a/src/test/java/org/tw/token_billing/service/UsageServiceTest.java
+++ b/src/test/java/org/tw/token_billing/service/UsageServiceTest.java
@@ -16,7 +16,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.temporal.TemporalAdjusters;
-import java.util.Optional;
+import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -63,8 +63,8 @@ class UsageServiceTest {
     }
 
     private void mockUsage(CustomerSubscription subscription, long currentMonthUsage) {
-        when(subscriptionRepository.findActiveSubscription(any(), any()))
-            .thenReturn(Optional.of(subscription));
+        when(subscriptionRepository.findAllActiveSubscriptions(any(), any()))
+            .thenReturn(List.of(subscription));
         when(billRepository.sumTotalTokensByCustomerIdAndMonthStart(any(), any()))
             .thenReturn(currentMonthUsage);
     }
@@ -167,15 +167,31 @@ class UsageServiceTest {
     // -------- Errors --------
 
     @Test
-    void calculateBill_customerNotFound_throwsException() {
-        when(subscriptionRepository.findActiveSubscription(any(), any())).thenReturn(Optional.empty());
+    void calculateBill_noActiveSubscription_throwsException() {
+        when(subscriptionRepository.findAllActiveSubscriptions(any(), any()))
+            .thenReturn(List.of());
 
-        var ex = assertThrows(UsageService.CustomerNotFoundException.class,
-            () -> usageService.calculateBill(new UsageRequest("INVALID", 1000, 1000)));
-        assertTrue(ex.getMessage().contains("INVALID"),
+        var ex = assertThrows(UsageService.NoActiveSubscriptionException.class,
+            () -> usageService.calculateBill(new UsageRequest("CUST-004", 1000, 1000)));
+        assertTrue(ex.getMessage().contains("CUST-004"),
             "Exception message should include customerId");
-        assertTrue(ex.getMessage().toLowerCase().contains("subscription"),
-            "Exception message should mention subscription, not just 'customer not found'");
+        assertTrue(ex.getMessage().toLowerCase().contains("no active"),
+            "Exception message should mention no active subscription");
+    }
+
+    @Test
+    void calculateBill_multipleActiveSubscriptions_throwsException() {
+        var sub1 = createSubscription("CUST-005", DEFAULT_QUOTA, DEFAULT_RATE);
+        var sub2 = createSubscription("CUST-005", 500000, new BigDecimal("0.0150"));
+        when(subscriptionRepository.findAllActiveSubscriptions(any(), any()))
+            .thenReturn(List.of(sub1, sub2));
+
+        var ex = assertThrows(UsageService.MultipleSubscriptionsException.class,
+            () -> usageService.calculateBill(new UsageRequest("CUST-005", 1000, 1000)));
+        assertTrue(ex.getMessage().contains("CUST-005"),
+            "Exception message should include customerId");
+        assertTrue(ex.getMessage().toLowerCase().contains("multiple"),
+            "Exception message should mention multiple subscriptions");
     }
 
     // -------- Persistence / interaction --------


### PR DESCRIPTION
## Summary

Implement subscription edge cases (issue #3) - Handle edge cases in subscription lookup:

- **No active subscription**: Returns HTTP 409 when customer has no active subscription (expired or no subscription)
- **Multiple active subscriptions**: Returns HTTP 500 with `log.error("Multiple active subscriptions for customerId={}", customerId)` - treated as data integrity error

### Changes

1. **UsageService.java**: Modified to use new `findAllActiveSubscriptions` method, added `NoActiveSubscriptionException` and `MultipleSubscriptionsException`
2. **CustomerSubscriptionRepository.java**: Added `findAllActiveSubscriptions` method returning List
3. **UsageController.java**: Added exception handlers for new exceptions (409 and 500)
4. **V1__Create_tables.sql**: Added seed data for test cases:
   - `CUST-004`: No active subscription (expired effective_to)
   - `CUST-005`: Multiple active subscriptions (data integrity error)
5. **UsageServiceTest.java**: Added test cases for edge cases

### Acceptance Criteria

- [x] No active subscription → HTTP 409
- [x] Data integrity error → HTTP 500 + log.error
- [x] `effective_from = today` (for active subscriptions)
- [x] `effective_to = today` and `effective_to = today - 1` (for expired)

@philipz can click here to [continue refining the PR](https://app.all-hands.dev/conversations/5549b6e0-d6b6-42fb-927d-2f6f4947dd5f)