### PR TITLE
Close issue #2 gaps: unknown-field + sequence tests

### DIFF
--- a/src/test/java/org/tw/token_billing/controller/UsageControllerTest.java
+++ b/src/test/java/org/tw/token_billing/controller/UsageControllerTest.java
@@ -19,6 +19,8 @@ import java.util.UUID;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -173,5 +175,47 @@ class UsageControllerTest {
             .andExpect(status().isBadRequest())
             .andExpect(content().contentTypeCompatibleWith("application/problem+json"))
             .andExpect(jsonPath("$.status").value(400));
+    }
+
+    // AC4: 400 - Unknown extra field rejected via fail-on-unknown-properties
+    @Test
+    void submitUsage_unknownExtraField_returns400WithRfc7807() throws Exception {
+        String body = "{\"customerId\":\"CUST-001\",\"promptTokens\":100,"
+                + "\"completionTokens\":100,\"unknownField\":\"value\"}";
+
+        mockMvc.perform(post("/api/usage")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+            .andExpect(status().isBadRequest())
+            .andExpect(content().contentTypeCompatibleWith("application/problem+json"))
+            .andExpect(jsonPath("$.type").value("about:blank"))
+            .andExpect(jsonPath("$.title").value("Invalid request body"))
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.instance").value("/api/usage"));
+
+        verify(usageService, never()).calculateBill(any(UsageRequest.class));
+    }
+
+    // AC9: SRS-F-6 sequence — body/field validation MUST short-circuit before
+    // customer lookup. If the body fails validation, the service must not be called
+    // even when the customerId would otherwise resolve to a 404.
+    @Test
+    void submitUsage_invalidBody_shortCircuitsBeforeCustomerLookup() throws Exception {
+        // Stub: if the service were ever called, it would return 404. We must see 400 instead.
+        when(usageService.calculateBill(any(UsageRequest.class)))
+            .thenThrow(new CustomerNotFoundException("CUST-MISSING"));
+
+        // customerId fails the regex AND would map to a non-existent customer
+        UsageRequest request = new UsageRequest("BAD@ID!", 100, 100);
+
+        mockMvc.perform(post("/api/usage")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest())
+            .andExpect(content().contentTypeCompatibleWith("application/problem+json"))
+            .andExpect(jsonPath("$.title").value("Invalid customer ID format"))
+            .andExpect(jsonPath("$.status").value(400));
+
+        verify(usageService, never()).calculateBill(any(UsageRequest.class));
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -7,3 +7,7 @@ spring:
   flyway:
     enabled: true
     locations: classpath:db/migration
+
+  jackson:
+    deserialization:
+      fail-on-unknown-properties: true


### PR DESCRIPTION
## Summary

Follow-up to PR #14 to close two acceptance criteria from issue #2 that
were merged without test coverage.

- **AC4 — unknown extra field rejected**: production `application.yml` sets
  `spring.jackson.deserialization.fail-on-unknown-properties=true`, but
  the test-scope `application.yml` omitted it. That's why the original
  unknown-field test (deleted in 2d7a725 as "flaky in WebMvcTest") was
  silently failing. Mirror the property into `src/test/resources/application.yml`
  and reinstate the test with full RFC 7807 envelope assertions.
- **AC9 — validation pipeline short-circuits before customer lookup**:
  the prior empty-body test only asserted status 400, not ordering. Add
  a sequence test that stubs the service to throw `CustomerNotFoundException`
  and sends a body with an invalid `customerId` pattern; assert 400 +
  `verify(usageService, never()).calculateBill(...)`, proving SRS-F-6
  step 3 short-circuits step 4.

Closes part of #2 (AC4 + AC9). The remaining ACs were already covered by PR #14.

## Test plan

- [x] `./gradlew test --tests "org.tw.token_billing.controller.UsageControllerTest"` — 10 tests, 0 failures
- [x] New `submitUsage_unknownExtraField_returns400WithRfc7807` asserts title `Invalid request body` + service not invoked
- [x] New `submitUsage_invalidBody_shortCircuitsBeforeCustomerLookup` asserts 400 (not 404) + service not invoked